### PR TITLE
Implement InterviewSim core models and tests

### DIFF
--- a/Domain/InterviewSim.Core/Class1.cs
+++ b/Domain/InterviewSim.Core/Class1.cs
@@ -1,6 +1,0 @@
-﻿namespace InterviewSim.Core;
-
-public class Class1
-{
-
-}

--- a/Domain/InterviewSim.Core/Dtos/CreditDto.cs
+++ b/Domain/InterviewSim.Core/Dtos/CreditDto.cs
@@ -1,0 +1,5 @@
+namespace InterviewSim.Core.Dtos;
+
+public readonly record struct CreditDto(
+    Guid UserId,
+    int Balance);

--- a/Domain/InterviewSim.Core/Dtos/InterviewSessionDto.cs
+++ b/Domain/InterviewSim.Core/Dtos/InterviewSessionDto.cs
@@ -1,0 +1,8 @@
+namespace InterviewSim.Core.Dtos;
+
+public readonly record struct InterviewSessionDto(
+    Guid Id,
+    Guid UserId,
+    DateTimeOffset StartedAt,
+    DateTimeOffset? CompletedAt,
+    IReadOnlyList<QuestionResponseDto> Responses);

--- a/Domain/InterviewSim.Core/Dtos/QuestionDto.cs
+++ b/Domain/InterviewSim.Core/Dtos/QuestionDto.cs
@@ -1,0 +1,11 @@
+namespace InterviewSim.Core.Dtos;
+
+using InterviewSim.Core.Entities;
+
+public readonly record struct QuestionDto(
+    string Id,
+    string Category,
+    string Difficulty,
+    string Prompt,
+    string? ReferenceSolution,
+    IReadOnlyList<RubricCriterionDto> Rubric);

--- a/Domain/InterviewSim.Core/Dtos/QuestionResponseDto.cs
+++ b/Domain/InterviewSim.Core/Dtos/QuestionResponseDto.cs
@@ -1,0 +1,6 @@
+namespace InterviewSim.Core.Dtos;
+
+public readonly record struct QuestionResponseDto(
+    string QuestionId,
+    string Response,
+    double? Score);

--- a/Domain/InterviewSim.Core/Dtos/RubricCriterionDto.cs
+++ b/Domain/InterviewSim.Core/Dtos/RubricCriterionDto.cs
@@ -1,0 +1,7 @@
+namespace InterviewSim.Core.Dtos;
+
+public readonly record struct RubricCriterionDto(
+    string Criterion,
+    double Weight,
+    string Excellent,
+    string Poor);

--- a/Domain/InterviewSim.Core/Dtos/UserDto.cs
+++ b/Domain/InterviewSim.Core/Dtos/UserDto.cs
@@ -1,0 +1,6 @@
+namespace InterviewSim.Core.Dtos;
+
+public readonly record struct UserDto(
+    Guid Id,
+    string Name,
+    int Credits);

--- a/Domain/InterviewSim.Core/Entities/Credit.cs
+++ b/Domain/InterviewSim.Core/Entities/Credit.cs
@@ -1,0 +1,5 @@
+namespace InterviewSim.Core.Entities;
+
+public record Credit(
+    Guid UserId,
+    int Balance);

--- a/Domain/InterviewSim.Core/Entities/InterviewSession.cs
+++ b/Domain/InterviewSim.Core/Entities/InterviewSession.cs
@@ -1,0 +1,8 @@
+namespace InterviewSim.Core.Entities;
+
+public record InterviewSession(
+    Guid Id,
+    Guid UserId,
+    DateTimeOffset StartedAt,
+    DateTimeOffset? CompletedAt,
+    IReadOnlyList<QuestionResponse> Responses);

--- a/Domain/InterviewSim.Core/Entities/Question.cs
+++ b/Domain/InterviewSim.Core/Entities/Question.cs
@@ -1,0 +1,9 @@
+namespace InterviewSim.Core.Entities;
+
+public record Question(
+    string Id,
+    string Category,
+    string Difficulty,
+    string Prompt,
+    string? ReferenceSolution,
+    IReadOnlyList<RubricCriterion> Rubric);

--- a/Domain/InterviewSim.Core/Entities/QuestionResponse.cs
+++ b/Domain/InterviewSim.Core/Entities/QuestionResponse.cs
@@ -1,0 +1,6 @@
+namespace InterviewSim.Core.Entities;
+
+public record QuestionResponse(
+    string QuestionId,
+    string Response,
+    double? Score);

--- a/Domain/InterviewSim.Core/Entities/RubricCriterion.cs
+++ b/Domain/InterviewSim.Core/Entities/RubricCriterion.cs
@@ -1,0 +1,7 @@
+namespace InterviewSim.Core.Entities;
+
+public record RubricCriterion(
+    string Criterion,
+    double Weight,
+    string Excellent,
+    string Poor);

--- a/Domain/InterviewSim.Core/Entities/User.cs
+++ b/Domain/InterviewSim.Core/Entities/User.cs
@@ -1,0 +1,6 @@
+namespace InterviewSim.Core.Entities;
+
+public record User(
+    Guid Id,
+    string Name,
+    int Credits);

--- a/Domain/InterviewSim.Core/Services/ICreditService.cs
+++ b/Domain/InterviewSim.Core/Services/ICreditService.cs
@@ -1,0 +1,7 @@
+namespace InterviewSim.Core.Services;
+
+public interface ICreditService
+{
+    Task<int> GetCreditsAsync(Guid userId, CancellationToken cancellationToken = default);
+    Task<bool> DeductCreditsAsync(Guid userId, int amount, CancellationToken cancellationToken = default);
+}

--- a/Domain/InterviewSim.Core/Services/IGradingService.cs
+++ b/Domain/InterviewSim.Core/Services/IGradingService.cs
@@ -1,0 +1,8 @@
+namespace InterviewSim.Core.Services;
+
+using InterviewSim.Core.Entities;
+
+public interface IGradingService
+{
+    Task<double> GradeAsync(Question question, string answer, CancellationToken cancellationToken = default);
+}

--- a/Domain/InterviewSim.Core/Services/IPdfReportService.cs
+++ b/Domain/InterviewSim.Core/Services/IPdfReportService.cs
@@ -1,0 +1,8 @@
+namespace InterviewSim.Core.Services;
+
+using InterviewSim.Core.Entities;
+
+public interface IPdfReportService
+{
+    Task<byte[]> GenerateReportAsync(InterviewSession session, CancellationToken cancellationToken = default);
+}

--- a/Domain/InterviewSim.Core/Services/IQuestionBankService.cs
+++ b/Domain/InterviewSim.Core/Services/IQuestionBankService.cs
@@ -1,0 +1,8 @@
+namespace InterviewSim.Core.Services;
+
+using InterviewSim.Core.Entities;
+
+public interface IQuestionBankService
+{
+    Task<IReadOnlyList<Question>> GetQuestionsAsync(CancellationToken cancellationToken = default);
+}

--- a/InterviewSim.sln
+++ b/InterviewSim.sln
@@ -15,6 +15,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Client", "Client", "{A8E569
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "InterviewSim.Client", "Client\InterviewSim.Client\InterviewSim.Client.csproj", "{EB54316E-A69B-4014-8C2E-B184D050A397}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{EBDE3514-5453-4F07-87BC-3CF0206E14FB}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "InterviewSim.Core.Tests", "tests\InterviewSim.Core.Tests\InterviewSim.Core.Tests.csproj", "{9126A07A-3FDD-40CC-BEAF-F662EE43A7FF}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -36,10 +40,15 @@ Global
 		{EB54316E-A69B-4014-8C2E-B184D050A397}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{EB54316E-A69B-4014-8C2E-B184D050A397}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{EB54316E-A69B-4014-8C2E-B184D050A397}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9126A07A-3FDD-40CC-BEAF-F662EE43A7FF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9126A07A-3FDD-40CC-BEAF-F662EE43A7FF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9126A07A-3FDD-40CC-BEAF-F662EE43A7FF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9126A07A-3FDD-40CC-BEAF-F662EE43A7FF}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{035061D3-8776-4CBB-8338-489A4680845F} = {4CFFE438-A2F4-48BA-A0B0-609FAF5FED0A}
 		{30280BDB-A655-43E3-9C6A-DDD762CFCB5D} = {6B4F255E-08E2-4CB4-B235-F0C1FD60FBF9}
 		{EB54316E-A69B-4014-8C2E-B184D050A397} = {A8E569C7-24FA-4DD7-82AF-1A873E660B05}
+		{9126A07A-3FDD-40CC-BEAF-F662EE43A7FF} = {EBDE3514-5453-4F07-87BC-3CF0206E14FB}
 	EndGlobalSection
 EndGlobal

--- a/tests/InterviewSim.Core.Tests/InterviewSim.Core.Tests.csproj
+++ b/tests/InterviewSim.Core.Tests/InterviewSim.Core.Tests.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Domain\InterviewSim.Core\InterviewSim.Core.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/InterviewSim.Core.Tests/RubricCriterionTests.cs
+++ b/tests/InterviewSim.Core.Tests/RubricCriterionTests.cs
@@ -1,0 +1,29 @@
+using InterviewSim.Core.Entities;
+using System.Linq;
+using Xunit;
+
+namespace InterviewSim.Core.Tests;
+
+public class RubricCriterionTests
+{
+    [Fact]
+    public void Weights_Should_Sum_To_One()
+    {
+        var question = new Question(
+            Id: "Q1",
+            Category: "algorithms",
+            Difficulty: "easy",
+            Prompt: "prompt",
+            ReferenceSolution: null,
+            Rubric: new[]
+            {
+                new RubricCriterion("correctness", 0.5, "good", "bad"),
+                new RubricCriterion("design", 0.3, "good", "bad"),
+                new RubricCriterion("communication", 0.2, "good", "bad")
+            });
+
+        var total = question.Rubric.Sum(r => r.Weight);
+
+        Assert.Equal(1d, total, 5);
+    }
+}


### PR DESCRIPTION
## Summary
- flesh out domain models for InterviewSim.Core
- introduce DTOs for API contracts
- define service interfaces using async patterns
- add xUnit test project with RubricCriterion weight check

## Testing
- `dotnet restore InterviewSim.sln`
- `dotnet build tests/InterviewSim.Core.Tests/InterviewSim.Core.Tests.csproj -warnaserror`
- `dotnet test tests/InterviewSim.Core.Tests/InterviewSim.Core.Tests.csproj --no-build`

------
https://chatgpt.com/codex/tasks/task_e_6846d6d1fab88322afe5aac1ca9be903