### PR TITLE
Add EF Core data layer

### DIFF
--- a/Domain/InterviewSim.Core/Data/InterviewSimContext.cs
+++ b/Domain/InterviewSim.Core/Data/InterviewSimContext.cs
@@ -1,0 +1,135 @@
+using System.Text.Json;
+using InterviewSim.Core.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace InterviewSim.Core.Data;
+
+public class InterviewSimContext : DbContext
+{
+    public InterviewSimContext(DbContextOptions<InterviewSimContext> options) : base(options)
+    {
+    }
+
+    public DbSet<User> Users => Set<User>();
+    public DbSet<Credit> Credits => Set<Credit>();
+    public DbSet<InterviewSession> InterviewSessions => Set<InterviewSession>();
+    public DbSet<QuestionResponse> QuestionResponses => Set<QuestionResponse>();
+    public DbSet<Question> Questions => Set<Question>();
+    public DbSet<RubricCriterion> RubricCriteria => Set<RubricCriterion>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+
+        modelBuilder.Entity<User>(entity =>
+        {
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.Email).IsRequired();
+            entity.Property(e => e.HashedPassword).IsRequired();
+            entity.Property(e => e.CreatedUtc).IsRequired();
+        });
+
+        modelBuilder.Entity<Credit>(entity =>
+        {
+            entity.HasKey(e => e.Id);
+            entity.HasOne(e => e.User)
+                .WithOne(u => u.Credit)
+                .HasForeignKey<Credit>(e => e.UserId)
+                .OnDelete(DeleteBehavior.Cascade);
+        });
+
+        modelBuilder.Entity<InterviewSession>(entity =>
+        {
+            entity.HasKey(e => e.Id);
+            entity.HasOne(e => e.User)
+                .WithMany(u => u.Sessions)
+                .HasForeignKey(e => e.UserId)
+                .OnDelete(DeleteBehavior.Cascade);
+        });
+
+        modelBuilder.Entity<QuestionResponse>(entity =>
+        {
+            entity.HasKey(e => e.Id);
+            entity.HasOne(e => e.Session)
+                .WithMany(s => s.QuestionResponses)
+                .HasForeignKey(e => e.SessionId)
+                .OnDelete(DeleteBehavior.Cascade);
+        });
+
+        modelBuilder.Entity<Question>(entity =>
+        {
+            entity.HasKey(e => e.Id);
+        });
+
+        modelBuilder.Entity<RubricCriterion>(entity =>
+        {
+            entity.HasKey(e => e.Id);
+            entity.HasOne(e => e.Question)
+                .WithMany(q => q.Rubric)
+                .HasForeignKey(e => e.QuestionId)
+                .OnDelete(DeleteBehavior.Cascade);
+        });
+    }
+
+    public async Task MigrateAndSeedAsync(string questionJsonPath, CancellationToken cancellationToken = default)
+    {
+        await Database.EnsureCreatedAsync(cancellationToken);
+        if (Database.GetMigrations().Any())
+        {
+            await Database.MigrateAsync(cancellationToken);
+        }
+
+        if (!Questions.Any())
+        {
+            var text = await File.ReadAllTextAsync(questionJsonPath, cancellationToken);
+            var data = JsonSerializer.Deserialize<QuestionSeed>(text, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+            if (data?.Questions != null)
+            {
+                foreach (var q in data.Questions)
+                {
+                    var question = new Question
+                    {
+                        Id = q.Id,
+                        Category = q.Category,
+                        Difficulty = q.Difficulty,
+                        Prompt = q.Prompt,
+                        ReferenceSolution = q.ReferenceSolution
+                    };
+                    question.Rubric.AddRange(q.Rubric.Select(r => new RubricCriterion
+                    {
+                        QuestionId = q.Id,
+                        Criterion = r.Criterion,
+                        Weight = r.Weight,
+                        Excellent = r.Excellent,
+                        Poor = r.Poor
+                    }));
+                    Questions.Add(question);
+                }
+                await SaveChangesAsync(cancellationToken);
+            }
+        }
+    }
+
+    private sealed class QuestionSeed
+    {
+        public List<QuestionSeedItem> Questions { get; set; } = new();
+    }
+
+    private sealed class QuestionSeedItem
+    {
+        public string Id { get; set; } = string.Empty;
+        public string Category { get; set; } = string.Empty;
+        public string Difficulty { get; set; } = string.Empty;
+        public string Prompt { get; set; } = string.Empty;
+        public string? ReferenceSolution { get; set; }
+        public List<RubricSeedItem> Rubric { get; set; } = new();
+    }
+
+    private sealed class RubricSeedItem
+    {
+        public string Criterion { get; set; } = string.Empty;
+        public double Weight { get; set; }
+        public string Excellent { get; set; } = string.Empty;
+        public string Poor { get; set; } = string.Empty;
+    }
+}

--- a/Domain/InterviewSim.Core/Entities/Credit.cs
+++ b/Domain/InterviewSim.Core/Entities/Credit.cs
@@ -1,5 +1,13 @@
+using System;
+
 namespace InterviewSim.Core.Entities;
 
-public record Credit(
-    Guid UserId,
-    int Balance);
+public class Credit
+{
+    public Guid Id { get; set; }
+    public Guid UserId { get; set; }
+    public int Balance { get; set; }
+    public DateTime UpdatedUtc { get; set; }
+
+    public User User { get; set; } = null!;
+}

--- a/Domain/InterviewSim.Core/Entities/InterviewSession.cs
+++ b/Domain/InterviewSim.Core/Entities/InterviewSession.cs
@@ -1,8 +1,17 @@
+using System;
+using System.Collections.Generic;
+
 namespace InterviewSim.Core.Entities;
 
-public record InterviewSession(
-    Guid Id,
-    Guid UserId,
-    DateTimeOffset StartedAt,
-    DateTimeOffset? CompletedAt,
-    IReadOnlyList<QuestionResponse> Responses);
+public class InterviewSession
+{
+    public Guid Id { get; set; }
+    public Guid UserId { get; set; }
+    public DateTime StartedUtc { get; set; }
+    public DateTime? EndedUtc { get; set; }
+    public string Track { get; set; } = null!;
+    public string Difficulty { get; set; } = null!;
+
+    public User User { get; set; } = null!;
+    public List<QuestionResponse> QuestionResponses { get; set; } = new();
+}

--- a/Domain/InterviewSim.Core/Entities/Question.cs
+++ b/Domain/InterviewSim.Core/Entities/Question.cs
@@ -1,9 +1,14 @@
+using System.Collections.Generic;
+
 namespace InterviewSim.Core.Entities;
 
-public record Question(
-    string Id,
-    string Category,
-    string Difficulty,
-    string Prompt,
-    string? ReferenceSolution,
-    IReadOnlyList<RubricCriterion> Rubric);
+public class Question
+{
+    public string Id { get; set; } = null!;
+    public string Category { get; set; } = null!;
+    public string Difficulty { get; set; } = null!;
+    public string Prompt { get; set; } = null!;
+    public string? ReferenceSolution { get; set; }
+
+    public List<RubricCriterion> Rubric { get; set; } = new();
+}

--- a/Domain/InterviewSim.Core/Entities/QuestionResponse.cs
+++ b/Domain/InterviewSim.Core/Entities/QuestionResponse.cs
@@ -1,6 +1,16 @@
+using System;
+
 namespace InterviewSim.Core.Entities;
 
-public record QuestionResponse(
-    string QuestionId,
-    string Response,
-    double? Score);
+public class QuestionResponse
+{
+    public Guid Id { get; set; }
+    public Guid SessionId { get; set; }
+    public string QuestionId { get; set; } = null!;
+    public string AnswerText { get; set; } = null!;
+    public string? FeedbackJson { get; set; }
+    public string? ScoreJson { get; set; }
+    public int DurationSec { get; set; }
+
+    public InterviewSession Session { get; set; } = null!;
+}

--- a/Domain/InterviewSim.Core/Entities/RubricCriterion.cs
+++ b/Domain/InterviewSim.Core/Entities/RubricCriterion.cs
@@ -1,7 +1,15 @@
+using System;
+
 namespace InterviewSim.Core.Entities;
 
-public record RubricCriterion(
-    string Criterion,
-    double Weight,
-    string Excellent,
-    string Poor);
+public class RubricCriterion
+{
+    public int Id { get; set; }
+    public string QuestionId { get; set; } = null!;
+    public string Criterion { get; set; } = null!;
+    public double Weight { get; set; }
+    public string Excellent { get; set; } = null!;
+    public string Poor { get; set; } = null!;
+
+    public Question Question { get; set; } = null!;
+}

--- a/Domain/InterviewSim.Core/Entities/User.cs
+++ b/Domain/InterviewSim.Core/Entities/User.cs
@@ -1,6 +1,15 @@
+using System;
+using System.Collections.Generic;
+
 namespace InterviewSim.Core.Entities;
 
-public record User(
-    Guid Id,
-    string Name,
-    int Credits);
+public class User
+{
+    public Guid Id { get; set; }
+    public string Email { get; set; } = null!;
+    public string HashedPassword { get; set; } = null!;
+    public DateTime CreatedUtc { get; set; }
+
+    public Credit? Credit { get; set; }
+    public List<InterviewSession> Sessions { get; set; } = new();
+}

--- a/Domain/InterviewSim.Core/InterviewSim.Core.csproj
+++ b/Domain/InterviewSim.Core/InterviewSim.Core.csproj
@@ -1,9 +1,12 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
-
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.0" />
+  </ItemGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# InterviewSim
+
+After adding EF Core migrations, update the database with:
+
+```bash
+dotnet ef migrations add Init -p Domain/InterviewSim.Core/InterviewSim.Core.csproj -s Api/InterviewSim.Api/InterviewSim.Api.csproj
+
+dotnet ef database update -p Domain/InterviewSim.Core/InterviewSim.Core.csproj -s Api/InterviewSim.Api/InterviewSim.Api.csproj
+```
+
+These commands create the initial schema and apply it to the configured database.

--- a/tests/InterviewSim.Core.Tests/DataSeedingTests.cs
+++ b/tests/InterviewSim.Core.Tests/DataSeedingTests.cs
@@ -1,0 +1,28 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using InterviewSim.Core.Data;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace InterviewSim.Core.Tests;
+
+public class DataSeedingTests
+{
+    [Fact]
+    public async Task Seed_Loads_Questions()
+    {
+        var options = new DbContextOptionsBuilder<InterviewSimContext>()
+            .UseSqlite("Filename=:memory:")
+            .Options;
+
+        using var context = new InterviewSimContext(options);
+        await context.Database.OpenConnectionAsync();
+        var baseDir = AppContext.BaseDirectory;
+        var path = Path.GetFullPath(Path.Combine(baseDir, "..", "..", "..", "..", "..", "Data", "questions_v1.json"));
+        await context.MigrateAndSeedAsync(path);
+
+        var count = await context.Questions.CountAsync();
+        Assert.True(count > 0);
+    }
+}

--- a/tests/InterviewSim.Core.Tests/InterviewSim.Core.Tests.csproj
+++ b/tests/InterviewSim.Core.Tests/InterviewSim.Core.Tests.csproj
@@ -7,6 +7,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Domain\InterviewSim.Core\InterviewSim.Core.csproj" />

--- a/tests/InterviewSim.Core.Tests/RubricCriterionTests.cs
+++ b/tests/InterviewSim.Core.Tests/RubricCriterionTests.cs
@@ -1,4 +1,5 @@
 using InterviewSim.Core.Entities;
+using System.Collections.Generic;
 using System.Linq;
 using Xunit;
 
@@ -9,18 +10,19 @@ public class RubricCriterionTests
     [Fact]
     public void Weights_Should_Sum_To_One()
     {
-        var question = new Question(
-            Id: "Q1",
-            Category: "algorithms",
-            Difficulty: "easy",
-            Prompt: "prompt",
-            ReferenceSolution: null,
-            Rubric: new[]
+        var question = new Question
+        {
+            Id = "Q1",
+            Category = "algorithms",
+            Difficulty = "easy",
+            Prompt = "prompt",
+            Rubric = new List<RubricCriterion>
             {
-                new RubricCriterion("correctness", 0.5, "good", "bad"),
-                new RubricCriterion("design", 0.3, "good", "bad"),
-                new RubricCriterion("communication", 0.2, "good", "bad")
-            });
+                new() { QuestionId = "Q1", Criterion = "correctness", Weight = 0.5, Excellent = "good", Poor = "bad" },
+                new() { QuestionId = "Q1", Criterion = "design", Weight = 0.3, Excellent = "good", Poor = "bad" },
+                new() { QuestionId = "Q1", Criterion = "communication", Weight = 0.2, Excellent = "good", Poor = "bad" }
+            }
+        };
 
         var total = question.Rubric.Sum(r => r.Weight);
 


### PR DESCRIPTION
## Summary
- implement InterviewSimContext with EF Core
- create entity classes for ORM
- load seed questions from `questions_v1.json`
- include CLI documentation
- add tests for rubric weights and data seeding

## Testing
- `dotnet test --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_6846d96942d08322aef3205db1d9a751