### PR TITLE
Add Azure-based grading service

### DIFF
--- a/Api/InterviewSim.Api/GradingService.cs
+++ b/Api/InterviewSim.Api/GradingService.cs
@@ -1,0 +1,96 @@
+using System.Text.Json;
+using Azure.AI.OpenAI;
+using InterviewSim.Core.Dtos;
+using InterviewSim.Core.Entities;
+using InterviewSim.Core.Services;
+using Microsoft.Extensions.Logging;
+
+namespace InterviewSim.Api;
+
+public class GradingService : IGradingService
+{
+    private readonly IOpenAIClient _client;
+    private readonly ILogger<GradingService> _logger;
+    private readonly string _systemPrompt;
+    private readonly string _userPrompt;
+    private readonly JsonSerializerOptions _json = new() { PropertyNameCaseInsensitive = true };
+    private const double PricePer1K = 0.01;
+
+    public GradingService(IOpenAIClient client, IWebHostEnvironment env, ILogger<GradingService> logger)
+    {
+        _client = client;
+        _logger = logger;
+        var dir = Path.Combine(env.ContentRootPath, "..", "Prompts");
+        _systemPrompt = File.ReadAllText(Path.Combine(dir, "system.txt"));
+        _userPrompt = File.ReadAllText(Path.Combine(dir, "user.txt"));
+    }
+
+    public async Task<double> GradeAsync(Question question, string answer, CancellationToken cancellationToken = default)
+    {
+        var rubricJson = JsonSerializer.Serialize(question.Rubric.Select(r => new { r.Criterion, r.Weight, r.Excellent, r.Poor }), _json);
+        var user = _userPrompt.Replace("{reference}", question.ReferenceSolution ?? string.Empty)
+            .Replace("{rubric}", rubricJson)
+            .Replace("{answer}", answer);
+
+        var options = new ChatCompletionsOptions();
+        options.Messages.Add(new ChatRequestSystemMessage(_systemPrompt));
+        options.Messages.Add(new ChatRequestUserMessage(user));
+        options.Tools.Add(new ChatCompletionsFunctionToolDefinition(new FunctionDefinition
+        {
+            Name = "record_scores",
+            Description = "Return rubric scores",
+            Parameters = BinaryData.FromObjectAsJson(new
+            {
+                type = "object",
+                properties = new
+                {
+                    scores = new
+                    {
+                        type = "array",
+                        items = new
+                        {
+                            type = "object",
+                            properties = new { criterion = new { type = "string" }, score = new { type = "number" } },
+                            required = new[] { "criterion", "score" }
+                        }
+                    }
+                },
+                required = new[] { "scores" }
+            })
+        }));
+
+        ChatCompletions completion = null!;
+        var delay = TimeSpan.FromSeconds(1);
+        for (var attempt = 0; attempt < 3; attempt++)
+        {
+            try
+            {
+                completion = await _client.GetChatCompletionsAsync(options, cancellationToken);
+                break;
+            }
+            catch when (attempt < 2)
+            {
+                await Task.Delay(delay, cancellationToken);
+                delay *= 2;
+            }
+        }
+
+        if (completion.Usage is not null)
+        {
+            var tokens = completion.Usage.PromptTokens + completion.Usage.CompletionTokens;
+            var cost = tokens / 1000d * PricePer1K;
+            _logger.LogInformation("Grading cost {Tokens} tokens = ${Cost:F4}", tokens, cost);
+        }
+
+        var call = (ChatCompletionsFunctionToolCall)completion.Choices[0].Message.ToolCalls[0];
+        var scores = JsonSerializer.Deserialize<RubricScore[]>(call.Arguments, _json) ?? Array.Empty<RubricScore>();
+
+        double total = 0;
+        foreach (var r in question.Rubric)
+        {
+            var s = scores.FirstOrDefault(x => x.Criterion.Equals(r.Criterion, StringComparison.OrdinalIgnoreCase));
+            if (s != null) total += s.Score * r.Weight;
+        }
+        return total;
+    }
+}

--- a/Api/InterviewSim.Api/IOpenAIClient.cs
+++ b/Api/InterviewSim.Api/IOpenAIClient.cs
@@ -1,0 +1,8 @@
+using Azure.AI.OpenAI;
+
+namespace InterviewSim.Api;
+
+public interface IOpenAIClient
+{
+    Task<ChatCompletions> GetChatCompletionsAsync(ChatCompletionsOptions options, CancellationToken cancellationToken = default);
+}

--- a/Api/InterviewSim.Api/OpenAIClientAdapter.cs
+++ b/Api/InterviewSim.Api/OpenAIClientAdapter.cs
@@ -1,0 +1,20 @@
+using Azure.AI.OpenAI;
+
+namespace InterviewSim.Api;
+
+public class OpenAIClientAdapter : IOpenAIClient
+{
+    private readonly OpenAIClient _client;
+    private const string Deployment = "gpt-4o";
+
+    public OpenAIClientAdapter(OpenAIClient client)
+    {
+        _client = client;
+    }
+
+    public async Task<ChatCompletions> GetChatCompletionsAsync(ChatCompletionsOptions options, CancellationToken cancellationToken = default)
+    {
+        var resp = await _client.GetChatCompletionsAsync(Deployment, options, cancellationToken);
+        return resp.Value;
+    }
+}

--- a/Api/InterviewSim.Api/Program.cs
+++ b/Api/InterviewSim.Api/Program.cs
@@ -37,10 +37,10 @@ builder.Services.AddSingleton(_ => new StripeClient(builder.Configuration["Strip
 builder.Services.AddSingleton(_ => new OpenAIClient(
     new Uri(builder.Configuration["OpenAI:Endpoint"] ?? "http://localhost"),
     new AzureKeyCredential(builder.Configuration["OpenAI:ApiKey"] ?? string.Empty)));
+builder.Services.AddSingleton<IOpenAIClient, OpenAIClientAdapter>();
 builder.Services.AddSingleton(_ => new BlobServiceClient(
     builder.Configuration.GetConnectionString("Storage") ?? "UseDevelopmentStorage=true"));
-
-builder.Services.AddSingleton<IGradingService, DummyGradingService>();
+builder.Services.AddSingleton<IGradingService, GradingService>();
 
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(o =>

--- a/Domain/InterviewSim.Core/Dtos/RubricScore.cs
+++ b/Domain/InterviewSim.Core/Dtos/RubricScore.cs
@@ -1,0 +1,3 @@
+namespace InterviewSim.Core.Dtos;
+
+public record RubricScore(string Criterion, double Score);

--- a/Prompts/system.txt
+++ b/Prompts/system.txt
@@ -1,0 +1,1 @@
+You are an interview grading assistant. Use the provided reference solution and rubric to score the candidate's answer. Respond only using the specified tool.

--- a/Prompts/user.txt
+++ b/Prompts/user.txt
@@ -1,0 +1,8 @@
+Reference solution:
+{reference}
+
+Rubric:
+{rubric}
+
+Candidate answer:
+{answer}

--- a/tests/InterviewSim.Core.Tests/FakeEnvironment.cs
+++ b/tests/InterviewSim.Core.Tests/FakeEnvironment.cs
@@ -1,0 +1,15 @@
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Hosting;
+
+namespace InterviewSim.Core.Tests;
+
+public class FakeEnvironment : IWebHostEnvironment
+{
+    public string EnvironmentName { get; set; } = "Development";
+    public string ApplicationName { get; set; } = "Test";
+    public string WebRootPath { get; set; } = string.Empty;
+    public IFileProvider WebRootFileProvider { get; set; } = new NullFileProvider();
+    public string ContentRootPath { get; set; } = string.Empty;
+    public IFileProvider ContentRootFileProvider { get; set; } = new NullFileProvider();
+}

--- a/tests/InterviewSim.Core.Tests/FakeOpenAIClient.cs
+++ b/tests/InterviewSim.Core.Tests/FakeOpenAIClient.cs
@@ -1,0 +1,19 @@
+using Azure.AI.OpenAI;
+using InterviewSim.Api;
+
+namespace InterviewSim.Core.Tests;
+
+public class FakeOpenAIClient : IOpenAIClient
+{
+    private readonly ChatCompletions _response;
+
+    public FakeOpenAIClient(ChatCompletions response)
+    {
+        _response = response;
+    }
+
+    public Task<ChatCompletions> GetChatCompletionsAsync(ChatCompletionsOptions options, CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult(_response);
+    }
+}

--- a/tests/InterviewSim.Core.Tests/GradingServiceTests.cs
+++ b/tests/InterviewSim.Core.Tests/GradingServiceTests.cs
@@ -1,0 +1,47 @@
+using System.Text.Json;
+using Azure.AI.OpenAI;
+using InterviewSim.Api;
+using InterviewSim.Core.Dtos;
+using InterviewSim.Core.Entities;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace InterviewSim.Core.Tests;
+
+public class GradingServiceTests
+{
+    [Fact]
+    public async Task GradeAsync_Computes_Weighted_Score()
+    {
+        var question = new Question
+        {
+            ReferenceSolution = "ref",
+            Rubric = new()
+            {
+                new RubricCriterion { Criterion = "a", Weight = 0.5, Excellent = "", Poor = "" },
+                new RubricCriterion { Criterion = "b", Weight = 0.5, Excellent = "", Poor = "" }
+            }
+        };
+
+        var scores = new[] { new RubricScore("a", 1.0), new RubricScore("b", 0.5) };
+        var json = JsonSerializer.Serialize(scores);
+
+        var toolCall = new ChatCompletionsFunctionToolCall("1", "record_scores", json);
+        var message = new ChatResponseMessage(ChatRole.Assistant);
+        message.ToolCalls.Add(toolCall);
+        var choice = new ChatChoice(message);
+        var completions = new ChatCompletions();
+        completions.Choices.Add(choice);
+        completions.Usage = new CompletionsUsage(10, 10, 20);
+
+        var fakeClient = new FakeOpenAIClient(completions);
+        var baseDir = AppContext.BaseDirectory;
+        var root = Path.GetFullPath(Path.Combine(baseDir, "..", "..", "..", "..", ".."));
+        var env = new FakeEnvironment { ContentRootPath = Path.Combine(root, "Api") };
+        var service = new GradingService(fakeClient, env, NullLogger<GradingService>.Instance);
+
+        var result = await service.GradeAsync(question, "ans");
+
+        Assert.Equal(0.75, result, 2);
+    }
+}

--- a/tests/InterviewSim.Core.Tests/InterviewSim.Core.Tests.csproj
+++ b/tests/InterviewSim.Core.Tests/InterviewSim.Core.Tests.csproj
@@ -11,5 +11,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Domain\InterviewSim.Core\InterviewSim.Core.csproj" />
+    <ProjectReference Include="..\..\Api\InterviewSim.Api\InterviewSim.Api.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- implement `GradingService` that calls Azure OpenAI and parses rubric scores
- add OpenAI client abstraction and adapter
- include grading prompt templates
- register new service in the API
- provide fake client and environment for tests
- add unit tests for new service

## Testing
- `dotnet test ./tests/InterviewSim.Core.Tests/InterviewSim.Core.Tests.csproj -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846e0214fb4832299fce6b173124a70