### PR TITLE
Add speech recognition interop

### DIFF
--- a/Client/InterviewSim.Client/Components/BehavioralAnswerInput.razor
+++ b/Client/InterviewSim.Client/Components/BehavioralAnswerInput.razor
@@ -1,0 +1,82 @@
+@inject IJSRuntime JS
+
+<MudTextField @bind-Value="_text" Lines="5" Class="w-100" />
+<MudButton OnClick="ToggleRecording" Variant="Variant.Filled" Color="Color.Primary" Class="mt-2">
+    @_recording ? "Stop" : "Record"
+</MudButton>
+
+@code {
+    [Parameter] public string Value { get; set; } = string.Empty;
+    [Parameter] public EventCallback<string> ValueChanged { get; set; }
+
+    private string _text
+    {
+        get => Value;
+        set
+        {
+            if (Value != value)
+            {
+                Value = value;
+                ValueChanged.InvokeAsync(value);
+            }
+        }
+    }
+
+    private IJSObjectReference? _module;
+    private DotNetObjectReference<BehavioralAnswerInput>? _dotNetRef;
+    private bool _recording;
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            _module = await JS.InvokeAsync<IJSObjectReference>("import", "./js/stt.js");
+        }
+    }
+
+    private async Task ToggleRecording()
+    {
+        if (_module == null) return;
+
+        if (!_recording)
+        {
+            _dotNetRef = DotNetObjectReference.Create(this);
+            await _module.InvokeVoidAsync("start", _dotNetRef);
+        }
+        else
+        {
+            await _module.InvokeVoidAsync("stop");
+        }
+    }
+
+    [JSInvokable]
+    public Task OnStart()
+    {
+        _recording = true;
+        StateHasChanged();
+        return Task.CompletedTask;
+    }
+
+    [JSInvokable]
+    public Task OnEnd()
+    {
+        _recording = false;
+        StateHasChanged();
+        return Task.CompletedTask;
+    }
+
+    [JSInvokable]
+    public Task OnResult(string text)
+    {
+        _text = text;
+        StateHasChanged();
+        return Task.CompletedTask;
+    }
+
+    [JSInvokable]
+    public Task OnError(string error)
+    {
+        Console.Error.WriteLine(error);
+        return Task.CompletedTask;
+    }
+}

--- a/Client/InterviewSim.Client/wwwroot/index.html
+++ b/Client/InterviewSim.Client/wwwroot/index.html
@@ -26,6 +26,7 @@
         <a href="" class="reload">Reload</a>
         <a class="dismiss">🗙</a>
     </div>
+    <script src="js/stt.js"></script>
     <script src="_framework/blazor.webassembly.js"></script>
 </body>
 

--- a/Client/InterviewSim.Client/wwwroot/js/stt.js
+++ b/Client/InterviewSim.Client/wwwroot/js/stt.js
@@ -1,0 +1,28 @@
+export function start(dotNetRef) {
+    const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
+    if (!SpeechRecognition) {
+        console.warn('Speech recognition not supported');
+        return;
+    }
+    const recognition = new SpeechRecognition();
+    window._sttRecognition = recognition;
+    recognition.continuous = true;
+    recognition.interimResults = false;
+    recognition.onstart = () => dotNetRef.invokeMethodAsync('OnStart');
+    recognition.onend = () => dotNetRef.invokeMethodAsync('OnEnd');
+    recognition.onerror = (e) => dotNetRef.invokeMethodAsync('OnError', e.error);
+    recognition.onresult = (e) => {
+        let text = '';
+        for (let i = e.resultIndex; i < e.results.length; i++) {
+            text += e.results[i][0].transcript;
+        }
+        dotNetRef.invokeMethodAsync('OnResult', text);
+    };
+    recognition.start();
+}
+
+export function stop() {
+    if (window._sttRecognition) {
+        window._sttRecognition.stop();
+    }
+}


### PR DESCRIPTION
## Summary
- add Web Speech API wrapper for speech-to-text
- create `BehavioralAnswerInput` component using JS interop
- register JS file in Blazor app

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846e7cae43883229d3f303fe26ad300